### PR TITLE
add deployment number to preload template

### DIFF
--- a/preload/templates/cql.jinja
+++ b/preload/templates/cql.jinja
@@ -6,6 +6,7 @@ CREATE TABLE ooi.{{table.name}} (
     sensor text,
     method text,
     time double,
+    deployment int,
     id uuid,
     driver_timestamp double,
     ingestion_timestamp double,


### PR DESCRIPTION
Adding deployment number to key in cassandra schema tepmplate for identifying data between deployments during periods of overlap.